### PR TITLE
Update for usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 Version Checker
 
 ## Description 
-Check the version of your Mycroft install using this skill.
+Report the version of your Mycroft install (mycroft-core) and of the platform you are running on (e.g. "Mark 1, build 10").
 
 ## Examples 
 * "check version"
-* "find your version"
-* "check your platform build"
+* "what version are you running"
+* "what's your platform build"
 
 ## Credits 
 Mycroft AI

--- a/dialog/en-us/platform.build.none.dialog
+++ b/dialog/en-us/platform.build.none.dialog
@@ -1,1 +1,1 @@
-I don't have a platform build.
+I'm running on a device that does not have an official platform build number.

--- a/vocab/en-us/Check.voc
+++ b/vocab/en-us/Check.voc
@@ -1,0 +1,4 @@
+check
+find
+running
+what is

--- a/vocab/en-us/CheckKeyword.voc
+++ b/vocab/en-us/CheckKeyword.voc
@@ -1,2 +1,0 @@
-check
-find

--- a/vocab/en-us/PlatformBuild.voc
+++ b/vocab/en-us/PlatformBuild.voc
@@ -1,0 +1,3 @@
+platform build
+platform version
+firmware version

--- a/vocab/en-us/PlatformBuildKeyword.voc
+++ b/vocab/en-us/PlatformBuildKeyword.voc
@@ -1,2 +1,0 @@
-platform build
-platform version

--- a/vocab/en-us/Version.voc
+++ b/vocab/en-us/Version.voc
@@ -1,0 +1,3 @@
+version
+code
+release

--- a/vocab/en-us/VersionKeyword.voc
+++ b/vocab/en-us/VersionKeyword.voc
@@ -1,1 +1,0 @@
-version


### PR DESCRIPTION
Several minor changes:
* Extended the verbage based on observations of users attempting to trigger the checker
* Deactivated mouth events to allow the version # to show onscreen and not be overwritten by the speaking mouth
* Implemented 'best practice' naming of voc files
