### PR TITLE
Add major version upgrade agreement mechanism

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,9 @@ from adapt.intent import IntentBuilder
 
 from mycroft import Message
 from mycroft.skills.core import MycroftSkill
-from mycroft.version import CORE_VERSION_STR
+from mycroft.version import (
+    CORE_VERSION_MAJOR, CORE_VERSION_MINOR, CORE_VERSION_BUILD,
+    CORE_VERSION_STR )
 
 
 class VersionCheckerSkill(MycroftSkill):
@@ -41,30 +43,55 @@ class VersionCheckerSkill(MycroftSkill):
     def find_version(version_str):
         return list(map(int, version_str.split('.')))
 
+    @staticmethod
+    def ver_data(version_list):
+        return {'major': version_list[0],
+                'minor': version_list[1],
+                'build': version_list[2]}
+
     def check_version(self, message):
         # Report the version of mycroft-core software
-        cur_ver = self.find_version(CORE_VERSION_STR)
 
-        # alphaa fixes Mimic pronunciation
-        postfix = 'alphaa' if cur_ver < [1, 0, 0] else 'beta'
-
+        # display the version on the device screen and speak it
+        cur_ver = [CORE_VERSION_MAJOR, CORE_VERSION_MINOR, CORE_VERSION_BUILD]
         self.enclosure.deactivate_mouth_events()
-        self.enclosure.mouth_text(CORE_VERSION_STR + postfix[0])
-        data = {'version': CORE_VERSION_STR + ' ' + postfix}
-        self.speak_dialog('version', data)
+        self.enclosure.mouth_text(CORE_VERSION_STR + "b")  # b for Beta
+        self.speak_dialog('version', self.ver_data(cur_ver))
+        mycroft.util.wait_while_speaking()
+        self.enclosure.activate_mouth_events()
 
         try:
+            # Obtain the most recent release's verion # from Github
             request = requests.get(self.RELEASE_URL)
             new_ver_str = request.json()['tag_name'].replace('release/v', '')
             new_ver = self.find_version(new_ver_str)
+            new_ver = [18,8,0]  # TODO: Testing only!!!!!
+
+            allowed_ver = self.config_core.get("max_allowed_core_version",
+                                               cur_ver)
+
+            self.log.info("Current version: "+str(cur_ver))
+            self.log.info("Latest version: "+str(new_ver))
+            self.log.info("Allowed version: "+str(allowed_ver))
 
             if cur_ver == new_ver:
                 self.speak_dialog('version.latest')
+            elif new_ver > allowed_ver:
+                # Get user permission for major upgrade
+                resp = self.ask_yesno('major.upgrade',
+                                      data=self.ver_data(new_ver))
+                if resp == 'yes':
+                    # TODO write the local value str(new_ver[0])+"."+str(new_ver[1])
+                    self.save_upgrade_permission(new_ver)
+                    self.speak_dialog('upgrade.started')
+                    self.emitter.emit(Message('system.update'))
+                else:
+                    self.speak_dialog('major.upgrade.declined')
             elif cur_ver < new_ver:
-                self.speak_dialog('version.older', {'new_version': new_ver_str})
-                yes_words = set(self.translate_list('yes'))
-                should_upgrade = self.get_response('ask.upgrade')
-                if any(word in should_upgrade.split() for word in yes_words):
+                # Ask user if they want to update immediately
+                resp = self.ask_yesno('ask.upgrade',
+                                      data={'new_version': new_ver_str})
+                if resp == 'yes':
                     self.speak_dialog('upgrade.started')
                     self.emitter.emit(Message('system.update'))
                 else:
@@ -76,8 +103,20 @@ class VersionCheckerSkill(MycroftSkill):
         # NOTE: intentionally sticking with this deprecated API instead
         # of mycroft.audio.wait_while_speaking() so that this skill
         # works on 0.8.15+
-        mycroft.util.wait_while_speaking()
-        self.enclosure.activate_mouth_events()
+
+    def save_upgrade_permission(self, ver):
+        from mycroft.configuration.config import (
+            LocalConf, USER_CONFIG, Configuration
+        )
+
+        float_ver = ver[0] + ver[1]/10
+        new_conf_values = { "max_allowed_core_version": float_ver }
+
+        user_config = LocalConf(USER_CONFIG)
+        user_config.merge(new_conf_values)
+        user_config.store()
+
+        self.emitter.emit(Message('configuration.updated'))
 
     def check_platform_build(self, message):
         if 'platform_build' in self.config_core['enclosure']:

--- a/__init__.py
+++ b/__init__.py
@@ -13,31 +13,37 @@
 # limitations under the License.
 import re
 import requests
+from datetime import timedelta
 
 import mycroft.util
 from adapt.intent import IntentBuilder
-
 from mycroft import Message
-from mycroft.skills.core import MycroftSkill
+from mycroft.audio import wait_while_speaking, is_speaking
+from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.version import (
     CORE_VERSION_MAJOR, CORE_VERSION_MINOR, CORE_VERSION_BUILD,
-    CORE_VERSION_STR )
+    CORE_VERSION_STR)
+from mycroft.util.time import now_utc
+from mycroft.configuration.config import LocalConf, USER_CONFIG
 
 
 class VersionCheckerSkill(MycroftSkill):
-    RELEASE_URL = 'https://api.github.com/repos/mycroftai/mycroft-core/releases/latest'
+    RELEASE_URL = 'https://api.github.com/repos/mycroftai/mycroft-core/releases/latest'  # nopep8
 
     def __init__(self):
         super(VersionCheckerSkill, self).__init__("VersionCheckerSkill")
 
-    def initialize(self):
-        intent = IntentBuilder('CheckVersion').require('Check') \
-            .require('Version').build()
-        self.register_intent(intent, self.check_version)
+        # Latest versions is at least the current version
+        self.latest_ver = [CORE_VERSION_MAJOR,
+                           CORE_VERSION_MINOR,
+                           CORE_VERSION_BUILD]
 
-        intent = IntentBuilder('CheckPlatformBuild').require('Check') \
-            .require('PlatformBuild')
-        self.register_intent(intent, self.check_platform_build)
+    def initialize(self):
+        daily = 60 * 60 * 24  # seconds in a day
+        self.schedule_repeating_event(self.daily_version_check,
+                                      now_utc(),     # run asap
+                                      60 * 60 * 24,  # repeat daily
+                                      daily, name='DailyVersionCheck')
 
     @staticmethod
     def find_version(version_str):
@@ -49,75 +55,59 @@ class VersionCheckerSkill(MycroftSkill):
                 'minor': version_list[1],
                 'build': version_list[2]}
 
+    def query_for_latest_ver(self):
+        try:
+            request = requests.get(self.RELEASE_URL)
+            ver_str = request.json()['tag_name'].replace('release/v', '')
+            self.latest_ver = self.find_version(ver_str)
+        except Exception:
+            self.log.exception('Could not find latest version. ')
+
+    def get_allowed_ver(self):
+        v = self.config_core.get("max_allowed_core_version", None)
+        if v:
+            # Convert 18.2 into [18, 2, 999]
+            v = float(v)  # in case someone entered it as a string
+            return [int(v), int(str(v-int(v))[2:]), 999]
+        else:
+            # assume current major/minor version is legit
+            return [CORE_VERSION_MAJOR, CORE_VERSION_MINOR, 999]
+
+    @intent_handler(IntentBuilder("").require("Check").require("Version"))
     def check_version(self, message):
         # Report the version of mycroft-core software
+        self.query_for_latest_ver()
+        cur_ver = [CORE_VERSION_MAJOR, CORE_VERSION_MINOR, CORE_VERSION_BUILD]
+        new_ver = self.latest_ver
+        allowed_ver = self.get_allowed_ver()
+        self.log.info("Current version: "+str(cur_ver))
+        self.log.info("Latest version: "+str(new_ver))
+        self.log.info("Allowed version: "+str(allowed_ver))
 
         # display the version on the device screen and speak it
-        cur_ver = [CORE_VERSION_MAJOR, CORE_VERSION_MINOR, CORE_VERSION_BUILD]
         self.enclosure.deactivate_mouth_events()
         self.enclosure.mouth_text(CORE_VERSION_STR + "b")  # b for Beta
         self.speak_dialog('version', self.ver_data(cur_ver))
         mycroft.util.wait_while_speaking()
         self.enclosure.activate_mouth_events()
 
-        try:
-            # Obtain the most recent release's verion # from Github
-            request = requests.get(self.RELEASE_URL)
-            new_ver_str = request.json()['tag_name'].replace('release/v', '')
-            new_ver = self.find_version(new_ver_str)
-            new_ver = [18,8,0]  # TODO: Testing only!!!!!
+        if cur_ver == new_ver:
+            self.speak_dialog('version.latest')
+        elif new_ver > allowed_ver:
+            self._ask_about_major_upgrade()
+        elif cur_ver < new_ver:
+            # Ask user if they want to update immediately
+            resp = self.ask_yesno('ask.upgrade',
+                                  data=self.ver_data(new_ver))
+            if resp == 'yes':
+                self.speak_dialog('upgrade.started')
+                # TODO: On Github install, should we tell users how to update?
+                self.emitter.emit(Message('system.update'))
+            else:
+                self.speak_dialog('upgrade.cancelled')
 
-            allowed_ver = self.config_core.get("max_allowed_core_version",
-                                               cur_ver)
-
-            self.log.info("Current version: "+str(cur_ver))
-            self.log.info("Latest version: "+str(new_ver))
-            self.log.info("Allowed version: "+str(allowed_ver))
-
-            if cur_ver == new_ver:
-                self.speak_dialog('version.latest')
-            elif new_ver > allowed_ver:
-                # Get user permission for major upgrade
-                resp = self.ask_yesno('major.upgrade',
-                                      data=self.ver_data(new_ver))
-                if resp == 'yes':
-                    # TODO write the local value str(new_ver[0])+"."+str(new_ver[1])
-                    self.save_upgrade_permission(new_ver)
-                    self.speak_dialog('upgrade.started')
-                    self.emitter.emit(Message('system.update'))
-                else:
-                    self.speak_dialog('major.upgrade.declined')
-            elif cur_ver < new_ver:
-                # Ask user if they want to update immediately
-                resp = self.ask_yesno('ask.upgrade',
-                                      data={'new_version': new_ver_str})
-                if resp == 'yes':
-                    self.speak_dialog('upgrade.started')
-                    self.emitter.emit(Message('system.update'))
-                else:
-                    self.speak_dialog('upgrade.cancelled')
-
-        except Exception:
-            self.log.exception('Could not find latest version. ')
-
-        # NOTE: intentionally sticking with this deprecated API instead
-        # of mycroft.audio.wait_while_speaking() so that this skill
-        # works on 0.8.15+
-
-    def save_upgrade_permission(self, ver):
-        from mycroft.configuration.config import (
-            LocalConf, USER_CONFIG, Configuration
-        )
-
-        float_ver = ver[0] + ver[1]/10
-        new_conf_values = { "max_allowed_core_version": float_ver }
-
-        user_config = LocalConf(USER_CONFIG)
-        user_config.merge(new_conf_values)
-        user_config.store()
-
-        self.emitter.emit(Message('configuration.updated'))
-
+    @intent_handler(IntentBuilder("").require("Check").
+                    require("PlatformBuild"))
     def check_platform_build(self, message):
         if 'platform_build' in self.config_core['enclosure']:
             # Report the platform build (aka firmware version)
@@ -135,13 +125,73 @@ class VersionCheckerSkill(MycroftSkill):
         try:
             opsys = re.sub(r'\\[a-z]{1}', ' ', open("/etc/issue").readline())
             # just in case issue file contains cruft decorative or otherwise
-            if re.search('\w{2,}',opsys):
+            if re.search('\w{2,}', opsys):
                 self.speak('On operating system: ' + opsys)
         except Exception:
             self.log.exception('/etc/issue read failed. ')
 
-    def stop(self):
-        pass
+    ######################################################################
+    # Logic to handle changes in major version, e.g. 18.02.x -> 18.08.x
+    # System checks once a day for new versions and will prompt the user
+    # at next opportunity whenever there is a new major version (which
+    # requires permission before updating)
+
+    def daily_version_check(self, message):
+        self.query_for_latest_ver()
+
+        allowed_ver = self.get_allowed_ver()
+        if self.latest_ver > allowed_ver:
+            # At next opportunity, alert user about pending update
+            self.add_event('recognizer_loop:audio_output_end',
+                           self.on_user_activity)
+
+    def on_user_activity(self, message):
+        # When the unit speaks, consider the user active.  Queue up a
+        # notice of available update in 30 seconds.
+        self.cancel_scheduled_event('QueueNotice')
+        pause = now_utc() + timedelta(seconds=30)
+        self.schedule_event(self._queue_notice, pause, name='QueueNotice')
+
+        # Queued to notify now, don't bug again until at least the next day
+        self.remove_event('recognizer_loop:audio_output_end')
+        self.cancel_scheduled_event('DailyVersionCheck')
+        self.schedule_repeating_event(self.daily_version_check,
+                                      None,          # wait to run
+                                      60 * 60 * 24,  # seconds in a day
+                                      name='DailyVersionCheck')
+
+    def _queue_notice(self, message):
+        if is_speaking():
+            # Re-queue notice
+            self.on_user_activity(message)
+        else:
+            # Let the user know an update is ready
+            self._ask_about_major_upgrade()
+
+    def _ask_about_major_upgrade(self):
+        # Get user permission for major upgrade
+        resp = self.ask_yesno('major.upgrade',
+                              data=self.ver_data(self.latest_ver))
+        if resp == 'yes':
+            # Save consent
+            self.save_upgrade_permission(self.latest_ver)
+            self.speak_dialog('upgrade.started')
+            self.emitter.emit(Message('system.update'))
+        else:
+            self.speak_dialog('major.upgrade.declined')
+
+    def save_upgrade_permission(self, ver):
+        # Build version as float, e.g. [18,8,999] as 18.8
+        float_ver = ver[0] + ver[1]/10  # assumes minor is <= 9
+        new_conf_values = {"max_allowed_core_version": float_ver}
+
+        # Save under the user (e.g. ~/.mycroft/mycroft.conf)
+        user_config = LocalConf(USER_CONFIG)
+        user_config.merge(new_conf_values)
+        user_config.store()
+
+        # Notify all processes to update their loaded configs
+        self.emitter.emit(Message('configuration.updated'))
 
 
 def create_skill():

--- a/__init__.py
+++ b/__init__.py
@@ -68,7 +68,7 @@ class VersionCheckerSkill(MycroftSkill):
         if v:
             # Convert 18.2 into [18, 2, 999]
             v = float(v)  # in case someone entered it as a string
-            return [int(v), int(str(v-int(v))[2:]), 999]
+            return [int(v), int(str(round(v-int(v),2))[2:]), 999]
         else:
             # assume current major/minor version is legit
             return [CORE_VERSION_MAJOR, CORE_VERSION_MINOR, 999]

--- a/dialog/en-us/ask.upgrade.dialog
+++ b/dialog/en-us/ask.upgrade.dialog
@@ -1,2 +1,2 @@
-Would you like me to start the upgrade?
-Would you like me update to the latest version?
+Your version is outdated. The latest version is {{new_version}}.  Would you like me to start the upgrade?
+Your version is outdated. The latest version is {{new_version}}.  Would you like me update to the latest version?

--- a/dialog/en-us/ask.upgrade.dialog
+++ b/dialog/en-us/ask.upgrade.dialog
@@ -1,2 +1,2 @@
-Your version is outdated. The latest version is {{new_version}}.  Would you like me to start the upgrade?
-Your version is outdated. The latest version is {{new_version}}.  Would you like me update to the latest version?
+Your version is outdated. The latest version is {{major}} oh {{minor}}, release {{build}}.  Would you like me to start the upgrade?
+Your version is outdated. The latest version is {{major}} oh {{minor}}, release {{build}}.  Would you like me update to the latest version?

--- a/dialog/en-us/major.upgrade.declined.dialog
+++ b/dialog/en-us/major.upgrade.declined.dialog
@@ -1,0 +1,1 @@
+No problem, I'll stay with my current software for now.

--- a/dialog/en-us/major.upgrade.dialog
+++ b/dialog/en-us/major.upgrade.dialog
@@ -1,1 +1,1 @@
-The next update will move you to the new {{major}} oh {{minor}} branch.  Changing branches is usually painless.  However some skills might not be available under the new branch.  Would you like to make this upgrade?
+A major Mycroft software update is available.  This will move you to the new {{major}} oh {{minor}} branch.  Changing branches is usually painless.  However, some skills might not be available under the new branch.  Would you like to start this upgrade?

--- a/dialog/en-us/major.upgrade.dialog
+++ b/dialog/en-us/major.upgrade.dialog
@@ -1,0 +1,1 @@
+The next update will move you to the new {{major}} oh {{minor}} branch.  Changing branches is usually painless.  However some skills might not be available under the new branch.  Would you like to make this upgrade?

--- a/dialog/en-us/upgrade.cancelled.dialog
+++ b/dialog/en-us/upgrade.cancelled.dialog
@@ -1,2 +1,1 @@
-Okay, I won't upgrade the device.
-Okay, I won't upgrade to the latest version.
+Alright, I'll remain on the older version

--- a/dialog/en-us/upgrade.started.dialog
+++ b/dialog/en-us/upgrade.started.dialog
@@ -1,2 +1,1 @@
-I've started the upgrade.
-I've begun the upgrade.
+I've started the update in the background.  It can take a while to download and upgrade, but I'll be running the latest code soon.

--- a/dialog/en-us/version.dialog
+++ b/dialog/en-us/version.dialog
@@ -1,1 +1,1 @@
-I am running mycroft-core version {{version}}.
+I am running mycroft-core version {{major}} oh {{minor}}, release {{build}}

--- a/dialog/en-us/version.older.dialog
+++ b/dialog/en-us/version.older.dialog
@@ -1,1 +1,0 @@
-Your version is outdated. The latest version is {{new_version}}.

--- a/dialog/en-us/yes.list
+++ b/dialog/en-us/yes.list
@@ -1,4 +1,0 @@
-yes
-yep
-yeah
-sure


### PR DESCRIPTION
Interim checkin for a mechanism that gets user approval when there is a
major version change (e.g. 18.02.xx -> 18.08.xx).  When detected, the
user hears more details about the impact and is asked for confirmation
before the upgrade is allowed to continue.  This also updates the
USER/mycroft.conf with the "max_allowed_core_version" after the agreement,
which is used in the update cron job thereafter.

Also cleaned up some of the function calls and improved pronunciation of
the version numbers.