### PR TITLE
Updated translations: ['sv-se', 'de-de', 'ru-ru', 'es-es', 'ro-ro', 'hu-hu', 'nl-nl']

### DIFF
--- a/dialog/es-es/ask.upgrade.dialog
+++ b/dialog/es-es/ask.upgrade.dialog
@@ -1,0 +1,2 @@
+Tú versión ha caducado. La última versión es {{mayor}} punto {{minor}} - {{build}}.  ¿Quieres que empiece la actualización?
+Tu versión está desactualizada. La última versión es {{major}} punto {{minor}}, compilación {{build}}.  ¿Quieres que me actualice a la última versión?

--- a/dialog/es-es/major.upgrade.declined.dialog
+++ b/dialog/es-es/major.upgrade.declined.dialog
@@ -1,0 +1,1 @@
+No hay problema, me quedaré con la versión actual de mi software.

--- a/dialog/es-es/major.upgrade.dialog
+++ b/dialog/es-es/major.upgrade.dialog
@@ -1,0 +1,1 @@
+Hay una nueva actualización del software de Mycroft disponible. La cual te moverá a la nueva versión {{major}} punto {{minor}}.  El cambiar de versiones normalmente es sencillo . Sin embargo algunas habilidades pueden no estar disponibles bajo la nueva versión. ¿Quieres iniciar esta actualización?

--- a/dialog/es-es/platform.build.dialog
+++ b/dialog/es-es/platform.build.dialog
@@ -1,1 +1,1 @@
-Mi versión de plataforma es la {{build}}.
+Mi compilación es {{build}}.

--- a/dialog/es-es/platform.build.none.dialog
+++ b/dialog/es-es/platform.build.none.dialog
@@ -1,1 +1,1 @@
-Me estoy ejecutando en un dispositivo que no tiene un número de versión de plataforma oficial.
+Estoy funcionando en un dispositivo que no tiene un número de compilación oficial.

--- a/dialog/es-es/upgrade.cancelled.dialog
+++ b/dialog/es-es/upgrade.cancelled.dialog
@@ -1,0 +1,1 @@
+Está bien, Me quedaré en la versión antigua

--- a/dialog/es-es/upgrade.started.dialog
+++ b/dialog/es-es/upgrade.started.dialog
@@ -1,0 +1,1 @@
+Inicié la actualización en segundo plano.  Puede llevar un tiempo en descargar y actualizar pero estaré funcionando pronto con la última versión del código.

--- a/dialog/es-es/version.dialog
+++ b/dialog/es-es/version.dialog
@@ -1,1 +1,1 @@
-Estoy ejecutando la versión mycroft-core {{version}}.
+Me encuentro ejecutando la versión {{major}} punto {{minor}}, compilación {{build}} del mycroft-core

--- a/dialog/es-es/version.latest.dialog
+++ b/dialog/es-es/version.latest.dialog
@@ -1,1 +1,1 @@
-Tienes la última versión.
+Estás en la última versión.

--- a/dialog/es-es/version.older.dialog
+++ b/dialog/es-es/version.older.dialog
@@ -1,1 +1,0 @@
-Tu versión está anticuada. La última versión es la {{new_version}}.

--- a/dialog/ro-ro/ask.upgrade.dialog
+++ b/dialog/ro-ro/ask.upgrade.dialog
@@ -1,0 +1,2 @@
+Versiunea ta este depășită. Cea mai recentă versiune este {{major}} punct {{minor}}, release {{build}}  Dorești să încep actualizarea?
+Versiunea ta este depășită. Cea mai recentă versiune este {{major}} punct {{minor}}, release {{build}}.  Vrei să mă actualizez la cea mai recentă versiune?

--- a/dialog/ro-ro/major.upgrade.declined.dialog
+++ b/dialog/ro-ro/major.upgrade.declined.dialog
@@ -1,0 +1,1 @@
+Nici o problema, voi ramane cu software-ul meu curent pentru moment.

--- a/dialog/ro-ro/major.upgrade.dialog
+++ b/dialog/ro-ro/major.upgrade.dialog
@@ -1,0 +1,1 @@
+Este disponibilă o actualizare majoră a software-ului Mycroft.  Aceasta vă va muta în noua versiune {{major}} punct {{minor}}. Ramificațiile schimbării sunt, de obicei, nesemnificative. Totuși, este posibil ca unele abilități să nu fie disponibile în nouă versiune.  Ați dori să începeți această actualizare?

--- a/dialog/ro-ro/platform.build.dialog
+++ b/dialog/ro-ro/platform.build.dialog
@@ -1,0 +1,1 @@
+Versiunea software-ului platforma este {{build}}.

--- a/dialog/ro-ro/platform.build.none.dialog
+++ b/dialog/ro-ro/platform.build.none.dialog
@@ -1,0 +1,1 @@
+Sunt pe un dispozitiv care nu are un număr oficial de construire a platformei.

--- a/dialog/ro-ro/upgrade.cancelled.dialog
+++ b/dialog/ro-ro/upgrade.cancelled.dialog
@@ -1,0 +1,1 @@
+Bine, voi rămâne pe versiunea mai veche

--- a/dialog/ro-ro/upgrade.started.dialog
+++ b/dialog/ro-ro/upgrade.started.dialog
@@ -1,0 +1,1 @@
+Am început actualizarea în fundal. "Poate dura ceva timp până la descărcare și actualizare, dar în curând voi rula ultimul cod.

--- a/dialog/ro-ro/version.dialog
+++ b/dialog/ro-ro/version.dialog
@@ -1,0 +1,1 @@
+Folosesc versiunea mycroft-core {{major}} punct {{minor}}, release {{build}}

--- a/dialog/ro-ro/version.latest.dialog
+++ b/dialog/ro-ro/version.latest.dialog
@@ -1,0 +1,1 @@
+Sunteți pe ultima versiune.

--- a/vocab/es-es/Check.voc
+++ b/vocab/es-es/Check.voc
@@ -1,4 +1,4 @@
-comprueba
-busca
-ejecutando
-qué
+verifica
+encuentra
+(corriendo|ejecutando)
+(Qué es|Cuál es)

--- a/vocab/es-es/PlatformBuild.voc
+++ b/vocab/es-es/PlatformBuild.voc
@@ -1,3 +1,3 @@
-número de versión
+compilación de la plataforma
 versión de la plataforma
 versión del firmware

--- a/vocab/es-es/Version.voc
+++ b/vocab/es-es/Version.voc
@@ -1,3 +1,4 @@
 versión
 código
-lanzamiento
+versión
+software del sistema

--- a/vocab/ro-ro/Check.voc
+++ b/vocab/ro-ro/Check.voc
@@ -1,0 +1,4 @@
+Verifică
+găseste
+funcţionare
+ce este

--- a/vocab/ro-ro/PlatformBuild.voc
+++ b/vocab/ro-ro/PlatformBuild.voc
@@ -1,0 +1,3 @@
+construirea platformei
+versiunea platformei
+versiunea softului

--- a/vocab/ro-ro/Version.voc
+++ b/vocab/ro-ro/Version.voc
@@ -1,0 +1,4 @@
+Versiune
+cod
+lansare
+programul sistemului


### PR DESCRIPTION
Automatically generated PR from translate.mycroft.ai

The updated languages are:
- sv-se
- de-de
- ru-ru
- es-es
- ro-ro
- hu-hu
- nl-nl
