### PR TITLE
Handle each of the platforms separately

### DIFF
--- a/dialog/en-us/inform.github.dialog
+++ b/dialog/en-us/inform.github.dialog
@@ -1,0 +1,2 @@
+Your version is outdated. The latest version is {{major}} oh {{minor}}, release {{build}}. To upgrade run 'git pull' in the mycroft-core folder and restart me.
+

--- a/dialog/en-us/inform.picroft.dialog
+++ b/dialog/en-us/inform.picroft.dialog
@@ -1,0 +1,1 @@
+Your version is outdated. To upgrade picroft to {{major}} oh {{minor}}, release {{build}}. please restart the device, if you have updates set to manual you need to run "git pull" in the mycroft-core folder.

--- a/dialog/en-us/update.available.dialog
+++ b/dialog/en-us/update.available.dialog
@@ -1,0 +1,3 @@
+Your version is outdated. The latest version is {{major}} oh {{minor}}, release {{build}}.
+Your version is outdated. The latest version is {{major}} oh {{minor}}, release {{build}}.
+


### PR DESCRIPTION
- Mark-1 and old Picroft (Jessie): ask and perform upgrade
- Picroft: Provide Picroft instructions
- Unknown platform: Provide instructions for github update

The periodic question about updating is rescheduled after asking about the current version, this fixes the double query that otherwise would occur.