### PR TITLE
Fix start upgrade

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -146,7 +146,10 @@ class VersionCheckerSkill(MycroftSkill):
             if resp == 'yes':
                 self.speak_dialog('upgrade.started')
                 # TODO: On Github install, should we tell users how to update?
-                self.bus.emit(Message('system.update'))
+                plat = self.config_core.get('enclosure', {}).get('platform')
+                self.bus.emit(Message('system.update',
+                                      {'is_paired': True,
+                                       'platform': plat}))
             else:
                 self.speak_dialog('upgrade.cancelled')
         else:
@@ -240,7 +243,10 @@ class VersionCheckerSkill(MycroftSkill):
             # Save consent
             self.save_upgrade_permission(self.latest_ver)
             self.speak_dialog('upgrade.started')
-            self.bus.emit(Message('system.update'))
+            plat = self.config_core.get('enclosure', {}).get('platform')
+            self.bus.emit(Message('system.update',
+                                  {'is_paired': True,
+                                  'platform': plat}))
         else:
             self.speak_dialog('major.upgrade.declined')
 

--- a/__init__.py
+++ b/__init__.py
@@ -145,6 +145,7 @@ class VersionCheckerSkill(MycroftSkill):
                                   data=self.ver_data(new_ver))
             if resp == 'yes':
                 self.speak_dialog('upgrade.started')
+                self.save_upgrade_permission(self.latest_ver)
                 # TODO: On Github install, should we tell users how to update?
                 plat = self.config_core.get('enclosure', {}).get('platform')
                 self.bus.emit(Message('system.update',


### PR DESCRIPTION
Changes in the mycroft-wifi-setup handling of `system.update` was changed to handle the Mark-2 separately. this caused the update to require the platform field to work.