### PR TITLE
Get the latest version from tags rather than releases.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import re
-import requests
 from datetime import timedelta
 
-from adapt.intent import IntentBuilder
+import requests
+
 from mycroft import Message
-from mycroft.audio import wait_while_speaking, is_speaking
-from mycroft.skills.core import MycroftSkill, intent_handler
+from mycroft.audio import is_speaking
+from mycroft.skills import MycroftSkill, intent_handler, AdaptIntent
 from mycroft.version import (
-    CORE_VERSION_MAJOR, CORE_VERSION_MINOR, CORE_VERSION_BUILD,
-    CORE_VERSION_STR)
+    CORE_VERSION_MAJOR,
+    CORE_VERSION_MINOR,
+    CORE_VERSION_BUILD,
+    CORE_VERSION_STR
+)
 from mycroft.util.time import now_utc
 from mycroft.configuration.config import LocalConf, USER_CONFIG
 
@@ -146,7 +150,7 @@ class VersionCheckerSkill(MycroftSkill):
         else:
             return False
 
-    @intent_handler(IntentBuilder("").require("Check").require("Version"))
+    @intent_handler(AdaptIntent("").require("Check").require("Version"))
     def check_version(self, message):
         # Report the version of mycroft-core software
         self.query_for_latest_ver()
@@ -185,7 +189,7 @@ class VersionCheckerSkill(MycroftSkill):
             self.speak_dialog('update.available', data=self.ver_data(new_ver))
         self.reschedule_reminder()
 
-    @intent_handler(IntentBuilder("").require("Check").
+    @intent_handler(AdaptIntent("").require("Check").
                     require("PlatformBuild"))
     def check_platform_build(self, message):
         if 'platform_build' in self.config_core['enclosure']:

--- a/__init__.py
+++ b/__init__.py
@@ -151,7 +151,7 @@ class VersionCheckerSkill(MycroftSkill):
         else:
             return False
 
-    @intent_handler(AdaptIntent("").require("Check").require("Version"))
+    @intent_handler(AdaptIntent().require("Check").require("Version"))
     def check_version(self, message):
         # Report the version of mycroft-core software
         self.query_for_latest_ver()
@@ -190,7 +190,7 @@ class VersionCheckerSkill(MycroftSkill):
             self.speak_dialog('update.available', data=self.ver_data(new_ver))
         self.reschedule_reminder()
 
-    @intent_handler(AdaptIntent("").require("Check").
+    @intent_handler(AdaptIntent().require("Check").
                     require("PlatformBuild"))
     def check_platform_build(self, message):
         if 'platform_build' in self.config_core['enclosure']:

--- a/__init__.py
+++ b/__init__.py
@@ -93,7 +93,8 @@ class VersionCheckerSkill(MycroftSkill):
 
         This assumes versions are using the mycroft-core versioning system.
         """
-        versions = [self.find_version(version_str) for version_str in version_list]
+        versions = [self.find_version(version_str)
+                    for version_str in version_list]
         major, minor, patch = -1, -1, -1
         for version in versions:
             newer = False
@@ -131,7 +132,7 @@ class VersionCheckerSkill(MycroftSkill):
         if v:
             # Convert 18.2 into [18, 2, 999]
             v = float(v)  # in case someone entered it as a string
-            return [int(v), int(str(round(v-int(v),2))[2:]), 999]
+            return [int(v), int(str(round(v-int(v), 2))[2:]), 999]
         else:
             # assume current major/minor version is legit
             return [CORE_VERSION_MAJOR, CORE_VERSION_MINOR, 999]
@@ -198,7 +199,8 @@ class VersionCheckerSkill(MycroftSkill):
             self.enclosure.deactivate_mouth_events()
             self.enclosure.mouth_text(build)
 
-            self.speak_dialog('platform.build', data={'build': build}, wait=True)
+            self.speak_dialog('platform.build', data={
+                              'build': build}, wait=True)
 
             self.enclosure.activate_mouth_events()
         else:
@@ -278,7 +280,7 @@ class VersionCheckerSkill(MycroftSkill):
             plat = self.config_core.get('enclosure', {}).get('platform')
             self.bus.emit(Message('system.update',
                                   {'is_paired': True,
-                                  'platform': plat}))
+                                   'platform': plat}))
         else:
             self.speak_dialog('major.upgrade.declined')
 


### PR DESCRIPTION
#### Description
Previously the latest git release was used, however this can report false results between a new version being tagged and when the release notes are added to the mycroft-core repository.

The new version is tagged during the automated release process so this should always be the latest version.

#### Type of PR
- [x] Bugfix

#### Testing
Ask "Hey Mycroft, what version are you running".
Currently it will report that a new version "21.2.0" is available. 
After applying this update, the latest version should be reported correctly as 21.2.1.